### PR TITLE
Allow to fetching nested data

### DIFF
--- a/mmvb_backend/cases/api/serializers.py
+++ b/mmvb_backend/cases/api/serializers.py
@@ -94,3 +94,11 @@ class CaseSerializer(ModelSerializer):
         instance.refresh_from_db()
 
         return instance
+
+
+class CaseSetFullSerializer(ModelSerializer):
+    cases = CaseSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = CaseSet
+        fields = ["id", "name", "cases"]

--- a/mmvb_backend/cases/api/views.py
+++ b/mmvb_backend/cases/api/views.py
@@ -1,8 +1,12 @@
 from rest_framework.viewsets import ModelViewSet
 
-from cases.api.serializers import CaseSerializer, CaseSetSerializer
+from cases.api.serializers import (
+    CaseSerializer,
+    CaseSetFullSerializer,
+    CaseSetSerializer,
+)
 from cases.models import Case, CaseSet
-from common.utils import CamelCaseAutoSchema
+from common.utils import CamelCaseAutoSchema, is_true
 
 
 # TODO: properly document endpoints
@@ -20,3 +24,9 @@ class CaseSetViewSet(ModelViewSet):
 
     def get_queryset(self):
         return CaseSet.objects.all()
+
+    def retrieve(self, request, *args, **kwargs):
+        full = request.query_params.get("full", False)
+        if is_true(full):
+            self.serializer_class = CaseSetFullSerializer
+        return super().retrieve(request, *args, **kwargs)

--- a/mmvb_backend/common/utils.py
+++ b/mmvb_backend/common/utils.py
@@ -15,3 +15,7 @@ class CamelCaseAutoSchema(AutoSchema):
             new_result["required"] = list(map(camelcase, result["required"]))
 
         return new_result
+
+
+def is_true(value):
+    return str(value).lower() in ["1", "true", "yes"]


### PR DESCRIPTION
Implements CaseSet serialiser that serialises all the cases data with a nested serialiser.
Selectively changes serialiser for /case-sets/{id}/ endpoint if a full=true query parameter is passed.

Resolves #40 