### PR TITLE
Add missing created_on and modified_on fields to case_sets fixture

### DIFF
--- a/mmvb_backend/cases/fixtures/case_sets.json
+++ b/mmvb_backend/cases/fixtures/case_sets.json
@@ -5,7 +5,9 @@
   "fields": {
     "status": "created",
     "public": false,
-    "name": "Synthesised case set with 10 cases (4e6f19b5a52f4cd59645604d759a03d1)"
+    "name": "Synthesised case set with 10 cases (4e6f19b5a52f4cd59645604d759a03d1)",
+    "created_on": "2020-06-15T11:09:08.476Z",
+    "modified_on": "2020-06-15T11:09:08.498Z"
   }
 },
 {
@@ -14,7 +16,9 @@
   "fields": {
     "status": "created",
     "public": false,
-    "name": "Synthesised case set with 10 cases (517a8a7fd2864fcab845954006ac461a)"
+    "name": "Synthesised case set with 10 cases (517a8a7fd2864fcab845954006ac461a)",
+    "created_on": "2020-06-15T11:09:08.476Z",
+    "modified_on": "2020-06-15T11:09:08.498Z"
   }
 },
 {
@@ -23,7 +27,9 @@
   "fields": {
     "status": "created",
     "public": false,
-    "name": "Synthesised case set with 10 cases (f7c88c3dbb784d63a09fd56c26f7fe23)"
+    "name": "Synthesised case set with 10 cases (f7c88c3dbb784d63a09fd56c26f7fe23)",
+    "created_on": "2020-06-15T11:09:08.476Z",
+    "modified_on": "2020-06-15T11:09:08.498Z"
   }
 }
 ]

--- a/mmvb_backend/cases/fixtures/cases.json
+++ b/mmvb_backend/cases/fixtures/cases.json
@@ -5,6 +5,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -40,6 +42,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -83,6 +87,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -120,6 +126,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -157,6 +165,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -192,6 +202,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -229,6 +241,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -277,6 +291,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -320,6 +336,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -357,6 +375,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -394,6 +414,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -431,6 +453,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -468,6 +492,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -505,6 +531,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -546,6 +574,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -583,6 +613,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -620,6 +652,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -657,6 +691,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -700,6 +736,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -743,6 +781,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -780,6 +820,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -817,6 +859,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -860,6 +904,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -895,6 +941,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -932,6 +980,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -975,6 +1025,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -1012,6 +1064,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -1060,6 +1114,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -1097,6 +1153,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -1134,6 +1192,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -1177,6 +1237,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -1220,6 +1282,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -1257,6 +1321,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -1298,6 +1364,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {
@@ -1335,6 +1403,8 @@
   "fields": {
     "status": "created",
     "public": false,
+    "created_on": "2020-06-15T11:09:08.506Z",
+    "modified_on": "2020-06-15T11:09:08.526Z",
     "data": {
       "caseData": {
         "metaData": {


### PR DESCRIPTION
I just copied some timestamp over from another fixture. Hope that makes sense.
Got this error:

```
Problem installing fixture '/usr/src/app/mmvb_backend/cases/fixtures/case_sets.json': Could not load cases.CaseSet(pk=4e6f19b5-a52f-4cd5-9645-604d759a03d1): (1048, "Column 'created_on' cannot be null")
```
when loading_fixtures.