### PR TITLE
Fix metrics

### DIFF
--- a/mmvb_backend/metrics/implementations/correct_conditions_top_n.py
+++ b/mmvb_backend/metrics/implementations/correct_conditions_top_n.py
@@ -74,7 +74,9 @@ class CorrectConditionsTopN(Metric):
             ai_responses = case_response["responses"]
             for ai_implementation_id, response in ai_responses.items():
                 completed = response["status"] == COMPLETED
-                result_conditions = response.get("conditions", [])
+                result_conditions = response.get("value", {}).get(
+                    "conditions", []
+                )
 
                 correct_condition = case.data["valuesToPredict"][
                     "correctCondition"

--- a/mmvb_backend/metrics/implementations/correct_conditions_top_n.py
+++ b/mmvb_backend/metrics/implementations/correct_conditions_top_n.py
@@ -74,9 +74,8 @@ class CorrectConditionsTopN(Metric):
             ai_responses = case_response["responses"]
             for ai_implementation_id, response in ai_responses.items():
                 completed = response["status"] == COMPLETED
-                result_conditions = response.get("value", {}).get(
-                    "conditions", []
-                )
+                ai_response = response.get("value", {})
+                result_conditions = ai_response.get("conditions", [])
 
                 correct_condition = case.data["valuesToPredict"][
                     "correctCondition"

--- a/mmvb_backend/metrics/implementations/triage_match.py
+++ b/mmvb_backend/metrics/implementations/triage_match.py
@@ -71,7 +71,8 @@ class TriageMatch(Metric):
                 ]
                 triage_matches = int(
                     has_completed
-                    and response.get("triage", "") == expected_triage
+                    and response.get("value", {}).get("triage", "")
+                    == expected_triage
                 )
 
                 cases_metrics.setdefault(case_id, {}).update(

--- a/mmvb_backend/metrics/implementations/triage_match.py
+++ b/mmvb_backend/metrics/implementations/triage_match.py
@@ -69,10 +69,10 @@ class TriageMatch(Metric):
                 expected_triage = case.data["valuesToPredict"][
                     "expectedTriageLevel"
                 ]
+                ai_response = response.get("value", {})
                 triage_matches = int(
                     has_completed
-                    and response.get("value", {}).get("triage", "")
-                    == expected_triage
+                    and ai_response.get("triage", "") == expected_triage
                 )
 
                 cases_metrics.setdefault(case_id, {}).update(

--- a/mmvb_backend/metrics/implementations/triage_similarity.py
+++ b/mmvb_backend/metrics/implementations/triage_similarity.py
@@ -103,7 +103,9 @@ class TriageSimilarityBase(Metric):
                     ]
 
                     triage_similarity = cls._calculate_triage_similarity(
-                        expected_triage, response.get("triage", ""), soft=soft
+                        expected_triage,
+                        response.get("value", {}).get("triage", ""),
+                        soft=soft,
                     )
 
                 cases_metrics.setdefault(case_id, {}).update(

--- a/mmvb_backend/metrics/implementations/triage_similarity.py
+++ b/mmvb_backend/metrics/implementations/triage_similarity.py
@@ -101,10 +101,10 @@ class TriageSimilarityBase(Metric):
                     expected_triage = case.data["valuesToPredict"][
                         "expectedTriageLevel"
                     ]
-
+                    ai_response = response.get("value", {})
                     triage_similarity = cls._calculate_triage_similarity(
                         expected_triage,
-                        response.get("value", {}).get("triage", ""),
+                        ai_response.get("triage", ""),
                         soft=soft,
                     )
 


### PR DESCRIPTION
Get `value` before getting sub properties.

@adampbaker Is this how it was intended? Or should all the properties of `value` live on the same nesting level as status?